### PR TITLE
Add Underscore (opposite of CamelCase) and Tablize methods (pluraizing an underscore)

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -144,6 +144,28 @@ Language.prototype.isSingular = function (word) {
   return !this.isPlural(word);
 };
 
+
+/**
+ * Tableize the given `str`.
+ *
+ * Examples:
+ *
+ *    lingo.tableize('UserAccount');
+ *    // => "user_accounts"
+ *  
+ *    lingo.tableize('User');
+ *    // => "users"
+ *
+ * @param {String} str
+ * @return {String}
+ * @api public
+ */
+
+exports.tableize = function(str){
+  var underscored = exports.underscore(word);
+  return Language.pluralize(underscored);
+};
+
 /**
  * Perform `type` inflection rules on the given `word`.
  *

--- a/lib/lingo.js
+++ b/lib/lingo.js
@@ -93,6 +93,26 @@ exports.camelcase = function(str, uppercaseFirst){
 };
 
 /**
+ * Underscore the given `str`.
+ *
+ * Examples:
+ *
+ *    lingo.underscore('UserAccount');
+ *    // => "user_account"
+ *  
+ *    lingo.underscore('User');
+ *    // => "user"
+ *
+ * @param {String} str
+ * @return {String}
+ * @api public
+ */
+
+exports.underscore = function(str){
+  return str.replace(/([a-z\d])([A-Z])/g, '$1_$2').toLowerCase();
+};
+
+/**
  * Join an array with the given `last` string
  * which defaults to "and".
  *

--- a/test/inflection.en.test.js
+++ b/test/inflection.en.test.js
@@ -113,5 +113,12 @@ module.exports = {
     assert.equal(true, en.isSingular('dog'));
     assert.equal(false, en.isSingular('keys'));
     assert.equal(false, en.isSingular('foxes'));
+  },
+  
+  'test .tabelize()': function(assert){
+    assert.equal('user_accounts', en.tabelize('UserAccount'));
+    assert.equal('user', en.tabelize('User'));
+    assert.equal('monkeys', en.tabelize('Monkey'));
+    assert.equal('animals', en.tabelize('Animal'));
   }
 };

--- a/test/lingo.test.js
+++ b/test/lingo.test.js
@@ -23,6 +23,11 @@ module.exports = {
     assert.equal('UserRole', lingo.camelcase('user role', true));
   },
   
+  'test .underscore()': function(assert){
+    assert.equal('user', lingo.underscore('User'));
+    assert.equal('user_account', lingo.underscore('UserAccount'))
+  },
+  
   'test .join()': function(assert){
     assert.equal('foo', lingo.join(['foo']));
     assert.equal('foo and bar', lingo.join(['foo', 'bar']));


### PR DESCRIPTION
These are useful when using lingo to communicate with MySQL or Postgres in a Rails like fashion (knowing which table to use with a variable named 'User')
