### PR TITLE
Properly pluralize "play"

### DIFF
--- a/lib/languages/en.js
+++ b/lib/languages/en.js
@@ -91,7 +91,8 @@ en.irregular('i', 'we')
   .irregular('his', 'theirs')
   .irregular('its', 'theirs')
   .irregular('theirs', 'theirs')
-  .irregular('sex', 'sexes');
+  .irregular('sex', 'sexes')
+  .irregular('play', 'plays');
 
 /**
  * Default uncountables.

--- a/test/inflection.en.test.js
+++ b/test/inflection.en.test.js
@@ -71,6 +71,7 @@ module.exports = {
     assert.equal('indices', en.pluralize('index'));
     assert.equal('indices', en.pluralize('indice'));
     assert.equal('categories', en.pluralize('category'));
+    assert.equal('plays', en.pluralize('play'));
   },
   
   'test .singularize()': function(assert){


### PR DESCRIPTION
Fixes pluralization for word "play" (was "plaies" before).
