### PR TITLE
Properly pluralize capitalized words

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -10,6 +10,7 @@
  */
 
 var Language = require('./language');
+var lingo = require('./lingo');
 
 /**
  * Check if a `word` is uncountable.
@@ -101,6 +102,16 @@ Language.prototype.singular = function(rule, substitution){
  */
 
 Language.prototype.pluralize = function(word){
+  if( lingo.isCapitalized(word) ){
+    word = word.toLowerCase();
+    word = this.inflect(word, 'plural');
+    return lingo.capitalize(word);
+  }
+  if( lingo.isUpperCase(word) ){
+    word = word.toLowerCase();
+    word = this.inflect(word, 'plural');
+    return word.toUpperCase();
+  }
   return this.inflect(word, 'plural');
 };
 
@@ -129,6 +140,16 @@ Language.prototype.isPlural = function (word) {
  */
 
 Language.prototype.singularize = function (word) {
+  if( lingo.isCapitalized(word) ){
+    word = word.toLowerCase();
+    word = this.inflect(word, 'singular');
+    return lingo.capitalize(word);
+  }
+  if( lingo.isUpperCase(word) ){
+    word = word.toLowerCase();
+    word = this.inflect(word, 'singular');
+    return word.toUpperCase();
+  }
   return this.inflect(word, 'singular');
 };
 

--- a/lib/languages/en.js
+++ b/lib/languages/en.js
@@ -29,7 +29,7 @@ en.pluralNumbers(/[^1]/);
 en.plural(/$/, "s")
   .plural(/(s|ss|sh|ch|x|o)$/i, "$1es")
   .plural(/y$/i, "ies")
-  .plural(/(o|e)y$/i, "$1ys")
+  .plural(/(a|o|e)y$/i, "$1ys")
   .plural(/(octop|vir)us$/i, "$1i")
   .plural(/(alias|status)$/i, "$1es")
   .plural(/(bu)s$/i, "$1ses")
@@ -92,7 +92,21 @@ en.irregular('i', 'we')
   .irregular('its', 'theirs')
   .irregular('theirs', 'theirs')
   .irregular('sex', 'sexes')
-  .irregular('play', 'plays');
+  .irregular('taco', 'tacos')
+  .irregular('alumnus', 'alumni')
+  .irregular('catcus', 'cacti')
+  .irregular('focus', 'foci')
+  .irregular('fungus', 'fungi')
+  .irregular('nucleus', 'nuclei')
+  .irregular('radius', 'radii')
+  .irregular('stimulus', 'stimuli')
+  .irregular('analysis', 'analyses')
+  .irregular('crisis', 'crises')
+  .irregular('diagnosis', 'diagnoses')
+  .irregular('ellipsis', 'ellipses')
+  .irregular('beau', 'beaux')
+  .irregular('louse', 'lice')
+  .irregular('mouse', 'mice');
 
 /**
  * Default uncountables.

--- a/lib/languages/en.js
+++ b/lib/languages/en.js
@@ -91,7 +91,8 @@ en.irregular('i', 'we')
   .irregular('his', 'theirs')
   .irregular('its', 'theirs')
   .irregular('theirs', 'theirs')
-  .irregular('sex', 'sexes');
+  .irregular('sex', 'sexes')
+  .irregular('play', 'plays');
 
 /**
  * Default uncountables.

--- a/lib/lingo.js
+++ b/lib/lingo.js
@@ -67,29 +67,48 @@ exports.capitalize = function(str, allWords){
 };
 
 /**
- * Camel-case the given `str`.
+ * Check if the first letter of `str` is capitalized, or optionally `allWords`
  *
  * Examples:
  *
- *    lingo.camelcase('foo bar');
- *    // => "fooBar"
- *  
- *    lingo.camelcase('foo bar baz', true);
- *    // => "FooBarBaz"
+ *    lingo.isCapitalized('Hello');
+ *    // => true
+ *
+ *    lingo.isCapitalized('Hello there', true);
+ *    // => false
  *
  * @param {String} str
- * @param {Boolean} uppercaseFirst
- * @return {String}
+ * @param {Boolean} allWords
+ * @return {Boolean}
  * @api public
  */
 
-exports.camelcase = function(str, uppercaseFirst){
-  return str.replace(/[^\w\d ]+/g, '').split(' ').map(function(word, i){
-    if (i || (0 == i && uppercaseFirst)) {
-      word = exports.capitalize(word);
-    }
-    return word;
-  }).join('');
+exports.isCapitalized = function(str, allWords){
+  if (allWords) {
+    return str.split(' ').every(function(word){
+      return exports.isCapitalized(word);
+    });
+  }
+  if( str.length === 1 )
+    return str.charAt(0).toUpperCase() === str.charAt(0);
+  return str.charAt(0).toUpperCase() === str.charAt(0) && str.charAt(1).toUpperCase() !== str.charAt(1);
+};
+
+/**
+ * Check if `str` is uppercase
+ *
+ * Examples:
+ *
+ *    lingo.isUpperCase('foo');
+ *    // => "FOO"
+ *
+ * @param {String} str
+ * @return {Boolean}
+ * @api public
+ */
+
+exports.isUpperCase = function(str){
+  return str.toUpperCase() === str;
 };
 
 /**

--- a/test/inflection.en.test.js
+++ b/test/inflection.en.test.js
@@ -71,6 +71,7 @@ module.exports = {
     assert.equal('indices', en.pluralize('index'));
     assert.equal('indices', en.pluralize('indice'));
     assert.equal('categories', en.pluralize('category'));
+    assert.equal('plays', en.pluralize('play'));
   },
   
   'test .singularize()': function(assert){

--- a/test/inflection.en.test.js
+++ b/test/inflection.en.test.js
@@ -72,6 +72,23 @@ module.exports = {
     assert.equal('indices', en.pluralize('indice'));
     assert.equal('categories', en.pluralize('category'));
     assert.equal('plays', en.pluralize('play'));
+    assert.equal('alumni', en.pluralize('alumnus'));
+    assert.equal('tacos', en.pluralize('taco'));
+    assert.equal('cacti', en.pluralize('cactus'));
+    assert.equal('foci', en.pluralize('focus'));
+    assert.equal('fungi', en.pluralize('fungus'));
+    assert.equal('nuclei', en.pluralize('nucleus'));
+    assert.equal('radii', en.pluralize('radius'));
+    assert.equal('stimuli', en.pluralize('stimulus'));
+    assert.equal('analyses', en.pluralize('analysis'));
+    assert.equal('crises', en.pluralize('crisis'));
+    assert.equal('diagnoses', en.pluralize('diagnosis'));
+    assert.equal('ellipses', en.pluralize('ellipsis'));
+    assert.equal('beaux', en.pluralize('beau'));
+    assert.equal('lice', en.pluralize('louse'));
+    assert.equal('mice', en.pluralize('mouse'));
+    assert.equal('TESTS', en.pluralize('TEST'));
+    assert.equal('Tests', en.pluralize('Test'));
   },
   
   'test .singularize()': function(assert){
@@ -98,6 +115,24 @@ module.exports = {
     assert.equal('index', en.singularize('indices'));
     assert.equal('category', en.singularize('categories'));
     assert.equal('series', en.singularize('series'));
+    assert.equal('plays', en.singularize('play'));
+    assert.equal('alumnus', en.singularize('alumni'));
+    assert.equal('taco', en.singularize('tacos'));
+    assert.equal('cactus', en.singularize('cacti'));
+    assert.equal('focus', en.singularize('foci'));
+    assert.equal('fungus', en.singularize('fungi'));
+    assert.equal('nucleus', en.singularize('nuclei'));
+    assert.equal('radius', en.singularize('radii'));
+    assert.equal('stimulus', en.singularize('stimuli'));
+    assert.equal('analysis', en.singularize('analyses'));
+    assert.equal('crisis', en.singularize('crises'));
+    assert.equal('diagnosis', en.singularize('diagnoses'));
+    assert.equal('ellipsis', en.singularize('ellipses'));
+    assert.equal('beau', en.singularize('beaux'));
+    assert.equal('louse', en.singularize('lice'));
+    assert.equal('mouse', en.singularize('mice'));
+    assert.equal('TEST', en.singularize('TESTS'));
+    assert.equal('Test', en.singularize('Tests'));
   },
   
   'test .isPlural()': function(assert){

--- a/test/lingo.test.js
+++ b/test/lingo.test.js
@@ -15,6 +15,19 @@ module.exports = {
     assert.equal('Hello There', lingo.capitalize('hello there', true));
   },
   
+  'test .isCapitalized()': function(assert){
+    assert.equal(true, lingo.isCapitalized('Hello there'));
+    assert.equal(true, lingo.isCapitalized('Hello There', true));
+    assert.equal(false, lingo.isCapitalized('HeLlO'));
+    assert.equal(false, lingo.isCapitalized('HELlo ThErE', true));
+  },
+  
+  'test .isUpperCase()': function(assert){
+    assert.equal(true, lingo.isUpperCase('HELLO'));
+    assert.equal(true, lingo.isUpperCase('HELLO THERE'));
+    assert.equal(false, lingo.isUpperCase('Hello There'));
+  }
+  
   'test .camelcase()': function(assert){
     assert.equal('foo', lingo.camelcase('foo'));
     assert.equal('fooBar', lingo.camelcase('foo bar'));


### PR DESCRIPTION
Added a couple new methods to properly handle cases with capitalized and uppercased words:

"PLAY" --> "PLAYS", "Play" --> "Plays"

Also added some irregular exceptions for words that were being improperly converted.
