### PR TITLE
Properly pluralize 'photo' to 'photos'

### DIFF
--- a/lib/languages/en.js
+++ b/lib/languages/en.js
@@ -91,6 +91,7 @@ en.irregular('i', 'we')
   .irregular('its', 'theirs')
   .irregular('theirs', 'theirs')
   .irregular('sex', 'sexes')
+  .irregular('photo', 'photos')
   .irregular('video', 'videos')
   .irregular('rodeo', 'rodeos');
 


### PR DESCRIPTION
Matches the video/videos case that's already there.
