### PR TITLE
Singularize ss

### DIFF
--- a/lib/languages/en.js
+++ b/lib/languages/en.js
@@ -46,6 +46,7 @@ en.plural(/$/, "s")
  */
 
 en.singular(/s$/i, "")
+  .singular(/ss$/i, "ss")
   .singular(/(bu|mis|kis)s$/i, "$1s")
   .singular(/([ti])a$/i, "$1um")
   .singular(/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i, "$1$2sis")

--- a/test/inflection.en.test.js
+++ b/test/inflection.en.test.js
@@ -98,6 +98,8 @@ module.exports = {
     assert.equal('index', en.singularize('indices'));
     assert.equal('category', en.singularize('categories'));
     assert.equal('series', en.singularize('series'));
+    assert.equal('class', en.singularize('class'));
+    assert.equal('business', en.singularize('business'));
   },
   
   'test .isPlural()': function(){

--- a/test/lingo.test.js
+++ b/test/lingo.test.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var lingo = require('lingo')
+var lingo = require('./..')
   , assert = require('assert');
 
 module.exports = {

--- a/test/translation.test.js
+++ b/test/translation.test.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var lingo = require('lingo')
+var lingo = require('./..')
   , assert = require('assert')
   , en = lingo.en;
 


### PR DESCRIPTION
Two changes. 
1. Changed test to use a relative path. It was the only way I could get `make test` to run.
2. Add rules to singularize words ending in "-ss" such as "class" and "business".
