### PR TITLE
English: pluralize 'vowel+o' ending as 'vowel+o+s'

### DIFF
--- a/lib/languages/en.js
+++ b/lib/languages/en.js
@@ -27,6 +27,7 @@ en.pluralNumbers(/[^1]/);
 
 en.plural(/$/, "s")
   .plural(/(s|ss|sh|ch|x|o)$/i, "$1es")
+  .plural(/([aeiouy]o)$/i, "$1s")
   .plural(/y$/i, "ies")
   .plural(/(o|e)y$/i, "$1ys")
   .plural(/(octop|vir)us$/i, "$1i")


### PR DESCRIPTION
See:
- The Cambridge Grammar of the English Language (p. 1586, The alternation between ·s and ·es)
- http://english.stackexchange.com/questions/23229/is-there-a-good-rule-of-thumb-for-plurals-from-words-ending-in-o
- http://www.oxforddictionaries.com/us/words/plurals-of-nouns
